### PR TITLE
fix: `update_if_exists->concat_new_values` -> fields with NULL value cant be concat, update for the SQL to make a condition to it

### DIFF
--- a/src/insert_multiple.php
+++ b/src/insert_multiple.php
@@ -212,7 +212,7 @@ class insert_multiple {
 
           if ($this->concat_new_values) {
 
-            $updates[] = "{$field} = CONCAT({$field}, VALUES({$field}))";
+            $updates[] = "{$field} = IF({$field} IS NULL, VALUES({$field}), CONCAT({$field}, VALUES({$field})))";
 
           }
           elseif ($this->skip_if_already_exists) {


### PR DESCRIPTION
When the actual field have a NULL value, the SQL cant do a CONCAT, then a I update the query to make a condition, if the actual value is NULL the field is updated with new values, else then CONCAT.